### PR TITLE
Added support for Attoparsec parser

### DIFF
--- a/ini.cabal
+++ b/ini.cabal
@@ -1,5 +1,5 @@
 name:                ini
-version:             0.2.0
+version:             0.2.1
 synopsis:            Quick and easy configuration files in the INI format.
 description:         Quick and easy configuration files in the INI format.
 license:             BSD3

--- a/src/Data/Ini.hs
+++ b/src/Data/Ini.hs
@@ -40,6 +40,7 @@ module Data.Ini
   ,parseIni
   ,lookupValue
   ,readValue
+  ,readValueAT
    -- * Writing
   ,writeIniFile
   ,printIni
@@ -53,6 +54,7 @@ module Data.Ini
   where
 
 import           Control.Monad
+import           Control.Applicative ((<*))
 import           Data.Attoparsec.Combinator
 import           Data.Attoparsec.Text
 import           Data.Char
@@ -92,6 +94,13 @@ readValue :: Text -> Text -> (Text -> Either String (a, Text))
           -> Either String a
 readValue section key f ini =
   lookupValue section key ini >>= f >>= return . fst
+
+-- | Read a value using a reader from "Data.Attoparsec.Text".
+readValueAT :: Text -> Text -> Parser a
+          -> Ini
+          -> Either String a
+readValueAT section key f ini =
+  lookupValue section key ini >>= parseOnly (f <* (skipSpace >> endOfInput))
 
 -- | Print the INI config to a file.
 writeIniFile :: FilePath -> Ini -> IO ()


### PR DESCRIPTION
Hi,
I've been using your Ini package, for me its the one that strikes the better balance between simplicity and number of packages it depends on. Thanks!

However, I need a function that would parse ini values using attoparsec, which offers a much bigger set of parsers than Data.Text.Read, and since attoparsec is already a dependency, this comes 'for free'.

To avoid breaking API changes, I've added a new function `readValueAT`.

What do you think?
Thanks
