### PR TITLE
Derive "Semigroup Ini" for GHC 8.4 compatibility

### DIFF
--- a/ini.cabal
+++ b/ini.cabal
@@ -18,7 +18,7 @@ library
   ghc-options:       -Wall -O2
   extensions:        OverloadedStrings
   exposed-modules:   Data.Ini
-  build-depends:     base >= 4 && <5,
+  build-depends:     base >= 4.9 && <5,
                      attoparsec,
                      text,
                      unordered-containers

--- a/src/Data/Ini.hs
+++ b/src/Data/Ini.hs
@@ -79,7 +79,7 @@ import           Prelude                    hiding (takeWhile)
 
 -- | An INI configuration.
 newtype Ini = Ini { unIni :: HashMap Text (HashMap Text Text) }
-  deriving (Show, Monoid)
+  deriving (Show, Semigroup, Monoid)
 
 -- | Parse an INI file.
 readIniFile :: FilePath -> IO (Either String Ini)


### PR DESCRIPTION
Currently the build fails with:

```
src/Data/Ini.hs:82:19: error:
    • No instance for (Semigroup Ini)
        arising from the 'deriving' clause of a data type declaration
      Possible fix:
        use a standalone 'deriving instance' declaration,
          so you can specify the instance context yourself
    • When deriving the instance for (Monoid Ini)
   |
82 |   deriving (Show, Monoid)
   |                   ^^^^^^
```

on GHC 8.4.1. This patch fixes this by deriving Semigroup with GND. This should be compatible starting from base 4.9 (GHC 8.0). I do not know your policy with backwards compatibility, this PR currently drops GHC 7.* compatibility, but we can use CPP to conditonally derive or `semigroups` package as a compatibility layer.