### PR TITLE
Add semigroups as a dependency to fix build below GHC 8

### DIFF
--- a/ini.cabal
+++ b/ini.cabal
@@ -22,6 +22,8 @@ library
                      attoparsec,
                      text,
                      unordered-containers
+  if !impl(ghc >= 8)
+    build-depends: semigroups >= 0.10 && < 0.19
 
 source-repository head
   type:     git


### PR DESCRIPTION
closes #22