### PR TITLE
Make skipEndOfLine skip over spaces

### DIFF
--- a/src/Data/Ini.hs
+++ b/src/Data/Ini.hs
@@ -204,7 +204,7 @@ isDelim x = x == '=' || x == ':'
 
 -- | Skip end of line and whitespace beyond.
 skipEndOfLine :: Parser ()
-skipEndOfLine = skipWhile (\c -> isEndOfLine c)
+skipEndOfLine = skipWhile isSpace
 
 -- | Skip comments starting at the beginning of the line.
 skipComments :: Parser ()


### PR DESCRIPTION
If a line before a section is consisted only of spaces, that section (and everything below) is not parsed. This change fixes that behaviour.